### PR TITLE
rename create-2bttns-app npx to create-app

### DIFF
--- a/packages/create-app/package.json
+++ b/packages/create-app/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "@2bttns/create-app",
+  "version": "1.1.1-alpha",
+  "description": "Create your 2bttns app with a single command.",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/2bttns/2bttns"
+  },
+  "bin": {
+    "@2bttns/create-2bttns-app": "./dist/index.js"
+  },
+  "type": "module",
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "prebuild": "npm run unlink && rm -rf bin && rm -rf types",
+    "build": "ncc build src/index.ts -o dist",
+    "postbuild": "npm run link",
+    "unlink": "npm unlink @2bttns/create-app",
+    "link": "npm link @2bttns/create-app",
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [
+    "2bttns"
+  ],
+  "author": "",
+  "license": "MIT",
+  "devDependencies": {
+    "@types/got": "^9.6.12",
+    "@types/node": "^20.3.3",
+    "@types/tar": "^6.1.5",
+    "@vercel/ncc": "^0.36.1",
+    "got": "^13.0.0",
+    "tar": "^6.1.15",
+    "typescript": "^5.1.6"
+  }
+}


### PR DESCRIPTION
@DOORM4T I think this would be a good change for brevity's sake. I don't think I did this right though . (it crashes on build). Can you fix and ship to npm?