### PR TITLE
Text instructions (no back button due to bounce out nature)

### DIFF
--- a/app/src/pages/404.tsx
+++ b/app/src/pages/404.tsx
@@ -1,4 +1,4 @@
-import { Heading, VStack } from "@chakra-ui/react";
+import { Heading, VStack, Button, Text } from "@chakra-ui/react";
 import { useSession } from "next-auth/react";
 import Head from "next/head";
 import AdminLayout from "../features/layouts/containers/AdminLayout";
@@ -34,7 +34,8 @@ const FourOhFourPage: NextPageWithLayout = () => {
 function Content() {
   return (
     <VStack alignItems="center" justifyContent="center" height="100%">
-      <Heading marginTop="-5rem">404 - Page Not Found</Heading>
+      <Heading marginTop="-5rem">Oops! Something isn&apos;t right here.</Heading>
+      <Text>Close this page and try again.</Text>
     </VStack>
   );
 }


### PR DESCRIPTION
<img width="1863" alt="Screenshot 2024-02-09 at 2 57 10 PM" src="https://github.com/2bttns/2bttns/assets/47542119/b215719d-0d56-4398-b523-e7a368f16d60">
